### PR TITLE
Use exe directory for config

### DIFF
--- a/AutoBackup/Program.cs
+++ b/AutoBackup/Program.cs
@@ -26,7 +26,8 @@ namespace AutoBackup
 
         static void RunBackup()
         {
-            const string configPath = "config.xml";
+            var exeDir = AppDomain.CurrentDomain.BaseDirectory;
+            var configPath = Path.Combine(exeDir, "config.xml");
             if (!File.Exists(configPath))
             {
                 Console.WriteLine($"Config file not found: {configPath}");


### PR DESCRIPTION
## Summary
- resolve config file relative to the executable directory so it's found even when run from another path

## Testing
- `dotnet build AutoBackup.sln -c Release`
- `dotnet AutoBackup/AutoBackup/bin/Release/net8.0/AutoBackup.dll` with and without a nearby `config.xml`

------
https://chatgpt.com/codex/tasks/task_e_68510738a204832090c5760c6a7d9e76